### PR TITLE
Move entitlment stub dependecy to commons

### DIFF
--- a/components/org.wso2.carbon.identity.entitlement.proxy/pom.xml
+++ b/components/org.wso2.carbon.identity.entitlement.proxy/pom.xml
@@ -40,7 +40,7 @@
             <artifactId>org.wso2.carbon.user.mgt.stub</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
         </dependency>
         <dependency>
@@ -187,7 +187,7 @@
                             version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.base; version="${carbon.base.imp.pkg.version.range}",
                             org.wso2.carbon.identity.entitlement.stub.*;
-                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            version="${carbon.commons.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
                             org.wso2.carbon.identity.entitlement.proxy.*;

--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,9 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <groupId>org.wso2.carbon.commons</groupId>
                 <artifactId>org.wso2.carbon.identity.entitlement.stub</artifactId>
-                <version>${carbon.identity.framework.version}</version>
+                <version>${carbon.commons.version}</version>
             </dependency>
 
             <!-- Axis2 dependencies -->
@@ -365,6 +365,9 @@
 
         <!--Carbon component version-->
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
+
+        <carbon.commons.version>4.6.52</carbon.commons.version>
+        <carbon.commons.imp.pkg.version.range>[4.0.0, 5.0.0)</carbon.commons.imp.pkg.version.range>
 
         <!--Carbon Identity Framework version-->
         <carbon.identity.framework.version>5.5.0</carbon.identity.framework.version>


### PR DESCRIPTION
Same package is duplicated in 

carbon-commons https://github.com/wso2/carbon-commons/tree/master/service-stubs/org.wso2.carbon.identity.entitlement.stub

and

carbon-identity-framework https://github.com/wso2/carbon-identity-framework/tree/master/service-stubs/identity/org.wso2.carbon.identity.entitlement.stub

Since carbon deployment uses the one from carbon commons and carbon mediation uses the one from carbon-identity-framework we are getting duplicate jars.

GIT Issue:- https://github.com/wso2/product-ei/issues/2061